### PR TITLE
Allow adding items under creditCard from $options

### DIFF
--- a/src/Billable.php
+++ b/src/Billable.php
@@ -367,7 +367,7 @@ trait Billable
     public function createAsBraintreeCustomer($token, array $options = [])
     {
         $response = BraintreeCustomer::create(
-            array_merge($options, [
+            array_replace_recursive($options, [
                 'firstName' => Arr::get(explode(' ', $this->name), 0),
                 'lastName' => Arr::get(explode(' ', $this->name), 1),
                 'email' => $this->email,


### PR DESCRIPTION
Allow items below creditCard to be added from the $options array. E.g. billing address.