### PR TITLE
Allow passed in Braintree options for firstName, lastName, and email to be used 

### DIFF
--- a/src/Billable.php
+++ b/src/Billable.php
@@ -367,7 +367,7 @@ trait Billable
     public function createAsBraintreeCustomer($token, array $options = [])
     {
         $response = BraintreeCustomer::create(
-            array_replace_recursive($options, [
+            array_merge([
                 'firstName' => Arr::get(explode(' ', $this->name), 0),
                 'lastName' => Arr::get(explode(' ', $this->name), 1),
                 'email' => $this->email,
@@ -376,8 +376,8 @@ trait Billable
                     'options' => [
                         'verifyCard' => true,
                     ]
-                ],
-            ])
+                ]
+            ], $options)
         );
 
         if (! $response->success) {


### PR DESCRIPTION
In the docs: https://laravel.com/docs/5.2/billing#creating-subscriptions it says:

> If you would like to specify additional customer details, you may do so by passing them as the second argument to the create method

However, in the current implementation, the `firstName`, `lastName`, and `email` fields are always overwritten with values from the current model instance. This PR changes it so that that those values are set with the user entity information only if the keys are not present in the `$options` array. 

This was the previous approach, which preserved the `array_merge_recursive` usage, but felt a little dirty with the nested `Arr::get`.  
![screen shot 2016-05-25 at 9 13 02 am](https://cloud.githubusercontent.com/assets/122173/15547495/e9f06fbc-2258-11e6-8dcc-70616443e18f.png)