### PR TITLE
Error on swap subscription

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "1.0-dev"
+            "dev-master": "2.0-dev"
         }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "2.0-dev"
+            "dev-master": "1.0-dev"
         }
     }
 }

--- a/src/Subscription.php
+++ b/src/Subscription.php
@@ -35,7 +35,7 @@ class Subscription extends Model
     {
         $model = getenv('BRAINTREE_MODEL') ?: config('services.braintree.model');
 
-        return $this->belongsTo($model, 'user_id');
+        return $this->belongsTo($model, config('services.braintree.model_id', 'user_id'));
     }
 
     /**


### PR DESCRIPTION
When using a differerent Model object other than User, undefined error will occur as the 'user_id' is hardcoded. Since Cashier supports custom Models for the 'user' object, the related id should also be configurable. 

This issue will resolve the error "exception 'Symfony\Component\Debug\Exception\FatalErrorException' with message 'Call to a member function taxPercentage() on null' in ../vendor/laravel/cashier-braintree/src/Subscription.php" when trying to swap a subscription using a different Model other than User Model.