### PR TITLE
Add filename option for invoices

### DIFF
--- a/src/Billable.php
+++ b/src/Billable.php
@@ -199,11 +199,12 @@ trait Billable
      * @param  string  $id
      * @param  array   $data
      * @param  string  $storagePath
+     * @param  string  $filename
      * @return \Symfony\Component\HttpFoundation\Response
      */
-    public function downloadInvoice($id, array $data, $storagePath = null)
+    public function downloadInvoice($id, array $data, $storagePath = null, $filename = null)
     {
-        return $this->findInvoiceOrFail($id)->download($data, $storagePath);
+        return $this->findInvoiceOrFail($id)->download($data, $storagePath, $filename);
     }
 
     /**

--- a/src/Invoice.php
+++ b/src/Invoice.php
@@ -249,11 +249,16 @@ class Invoice
      * Create an invoice download response.
      *
      * @param  array   $data
+     * @param  string  $storagePath
+     * @param  string  $filename
      * @return \Symfony\Component\HttpFoundation\Response
      */
-    public function download(array $data)
+    public function download(array $data, $storagePath = null, $filename = null)
     {
-        $filename = $data['product'].'_'.$this->date()->month.'_'.$this->date()->year.'.pdf';
+        if (is_null($filename)) {
+            $filename = $data['product'].'_'.$this->date()->month.'_'.$this->date()->year;
+        }
+        $filename = $filename.'.pdf';
 
         return new Response($this->pdf($data), 200, [
             'Content-Description' => 'File Transfer',


### PR DESCRIPTION
The filename parameter was added to the end so that user code does not break with version update.

Also found a minor bug with the storagePath parameter. It was being passed into download() in the downloadInvoice() function, but storagePath wasn't expected by download() as a parameter, so I also added that in.