### PR TITLE
Drop PHP 5.5 Travis testing for Laravel 5.3 version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: php
 
 php:
-  - 5.5
   - 5.6
   - 7.0
   - hhvm


### PR DESCRIPTION
Laravel 5.3 is 5.6+.