### PR TITLE
Webhook cancel did not work for a subscription on a grace period

### DIFF
--- a/src/Http/Controllers/WebhookController.php
+++ b/src/Http/Controllers/WebhookController.php
@@ -76,8 +76,9 @@ class WebhookController extends Controller
     protected function cancelSubscription($subscriptionId)
     {
         $subscription = $this->getSubscriptionById($subscriptionId);
+        $should_cancel = ! $subscription->cancelled() || $subscription->onGracePeriod();
 
-        if ($subscription && ! $subscription->cancelled()) {
+        if ($subscription && $should_cancel) {
             $subscription->markAsCancelled();
         }
 

--- a/src/Http/Controllers/WebhookController.php
+++ b/src/Http/Controllers/WebhookController.php
@@ -76,9 +76,8 @@ class WebhookController extends Controller
     protected function cancelSubscription($subscriptionId)
     {
         $subscription = $this->getSubscriptionById($subscriptionId);
-        $should_cancel = ! $subscription->cancelled() || $subscription->onGracePeriod();
 
-        if ($subscription && $should_cancel) {
+        if ($subscription && (! $subscription->cancelled() || $subscription->onGracePeriod())) {
             $subscription->markAsCancelled();
         }
 


### PR DESCRIPTION
`WebhookController@cancelSubscription` would not mark the subscription as cancelled if the subscription was on a grace period.

This puts Braintree and the Cashier project out of sync. The customer was able to resume the subscription after that without error. As Braintree was not going to bill the customer, I can't imagine that the subscription would have ever cancelled.