### PR TITLE
Add use Exception in Cashier class

### DIFF
--- a/src/Cashier.php
+++ b/src/Cashier.php
@@ -2,6 +2,8 @@
 
 namespace Laravel\Cashier;
 
+use Exception;
+
 class Cashier
 {
     /**


### PR DESCRIPTION
Solution for Class 'Laravel\Cashier\Exception' not found, when throw Exception