### PR TITLE
Handling Braintree own error bag in exception + fix user not being returned correctly after updating card data + process foreign key not based on default model 'User' convention

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ composer.phar
 composer.lock
 .DS_Store
 Thumbs.db
+/.project

--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,7 @@
     "scripts": {
         "post-root-package-install": [
             "php -r \"file_exists('.env') || copy('.env.example', '.env');\""
-        ],
+        ]
     },
     "minimum-stability": "dev",
     "prefer-stable": true

--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,7 @@
         "branch-alias": {
             "dev-master": "2.0-dev"
         }
-    }
+    },
     "scripts": {
         "post-root-package-install": [
             "php -r \"file_exists('.env') || copy('.env.example', '.env');\""

--- a/src/Billable.php
+++ b/src/Billable.php
@@ -13,6 +13,7 @@ use Illuminate\Support\Collection;
 use Braintree\Customer as BraintreeCustomer;
 use Braintree\Transaction as BraintreeTransaction;
 use Braintree\Subscription as BraintreeSubscription;
+use Laravel\Cashier\Exceptions\BraintreeErrorException;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
 trait Billable
@@ -275,9 +276,10 @@ trait Billable
                 ],
             ], $options)
         );
-
+        
         if (! $response->success) {
-            throw new Exception('Braintree was unable to create a payment method: '.$response->message);
+            throw new BraintreeErrorException(
+                'Braintree was unable to create a payment method: '.$response->message, null, null, $response->errors);
         }
 
         $paypalAccount = $response->paymentMethod instanceof PaypalAccount;

--- a/src/Exceptions/BraintreeErrorException.php
+++ b/src/Exceptions/BraintreeErrorException.php
@@ -1,0 +1,22 @@
+<?php 
+
+namespace Laravel\Cashier\Exceptions;
+
+use Exception;
+
+class BraintreeErrorException extends Exception
+{
+    protected $errorObject;
+    
+    public function __construct($message = "", $code = 0, Exception $previous = null, $errorObject = null)
+    {
+        $this->errorObject = $errorObject;
+        
+        parent::__construct($message, $code, $previous);
+    }
+    
+    public function getErrorBag()
+    {
+        return $this->errorObject;
+    }
+}

--- a/src/Subscription.php
+++ b/src/Subscription.php
@@ -35,7 +35,7 @@ class Subscription extends Model
     {
         $model = getenv('BRAINTREE_MODEL') ?: config('services.braintree.model');
 
-        return $this->belongsTo($model, 'user_id');
+        return $this->belongsTo($model, config('services.braintree.model_foreign_key', 'user_id'));
     }
 
     /**

--- a/src/SubscriptionBuilder.php
+++ b/src/SubscriptionBuilder.php
@@ -216,10 +216,9 @@ class SubscriptionBuilder
         if (! $this->user->braintree_id) {
             $customer = $this->user->createAsBraintreeCustomer($token, $options);
         } else {
-            $customer = $this->user->asBraintreeCustomer();
-
             if ($token) {
                 $this->user->updateCard($token);
+                $customer = $this->user->asBraintreeCustomer();
             }
         }
 


### PR DESCRIPTION
[4e3b5a2] On getBraintreeCustomer, a customer wasn't correctly returned if the
card data was updated, giving an exception later as the customer haven't
any payment methods assigned.

[8f2aec1] Using a model different from User, has trouble when finding the default foreign key (user_id), so I made able to input a custom one via config file.

[26de63f] Sometimes exceptions show several errors when getting the exception message. Exception is too generic, so I added up a 'BraintreeException'. If Braintree returns its error bag, can be now retrieved from this exception, then it's possible to handle errors independently.