### PR TITLE
Fix returning correctly an updated customer if that customer already exists after updating card data

### DIFF
--- a/src/SubscriptionBuilder.php
+++ b/src/SubscriptionBuilder.php
@@ -216,10 +216,9 @@ class SubscriptionBuilder
         if (! $this->user->braintree_id) {
             $customer = $this->user->createAsBraintreeCustomer($token, $options);
         } else {
-            $customer = $this->user->asBraintreeCustomer();
-
             if ($token) {
                 $this->user->updateCard($token);
+                $customer = $this->user->asBraintreeCustomer();
             }
         }
 


### PR DESCRIPTION
On `getBraintreeCustomer`, a customer wasn't correctly returned if the card data was updated, giving an exception later as the customer haven't any payment methods assigned. (`getSubscriptionPayload` would fail when accessing `$customer->paymentMethods[0]`