### PR TITLE
Fix price after applying tax

### DIFF
--- a/src/Subscription.php
+++ b/src/Subscription.php
@@ -140,7 +140,7 @@ class Subscription extends Model
 
         $response = BraintreeSubscription::update($subscription->id, [
             'planId' => $plan->id,
-            'price' => $plan->price * (1 + ($this->owner->taxPercentage() / 100)),
+            'price' => (string) round($plan->price * (1 + ($this->owner->taxPercentage() / 100)), 2),
             'neverExpires' => true,
             'numberOfBillingCycles' => null,
             'options' => [

--- a/src/SubscriptionBuilder.php
+++ b/src/SubscriptionBuilder.php
@@ -177,7 +177,7 @@ class SubscriptionBuilder
 
         return array_merge([
             'planId' => $this->plan,
-            'price' => $plan->price * (1 + ($this->owner->taxPercentage() / 100)),
+            'price' => (string) round($plan->price * (1 + ($this->owner->taxPercentage() / 100)), 2),
             'paymentMethodToken' => $customer->paymentMethods[0]->token,
             'trialPeriod' => $this->trialDays && ! $this->skipTrial ? true : false,
             'trialDurationUnit' => 'day',


### PR DESCRIPTION
Braintree API throws an exception if the price is **10.123** which can be after applying the tax. Due to the documentation, it accepts a string in format 10 or 10.00