### PR TITLE
Fixed Dompdf call, when creating invoices.

### DIFF
--- a/src/Invoice.php
+++ b/src/Invoice.php
@@ -2,8 +2,8 @@
 
 namespace Laravel\Cashier;
 
-use DOMPDF;
 use Carbon\Carbon;
+use Dompdf\Dompdf;
 use Illuminate\Support\Facades\View;
 use Symfony\Component\HttpFoundation\Response;
 use Braintree\Transaction as BraintreeTransaction;
@@ -236,9 +236,9 @@ class Invoice
             require_once $configPath;
         }
 
-        $dompdf = new DOMPDF;
+        $dompdf = new Dompdf;
 
-        $dompdf->load_html($this->view($data)->render());
+        $dompdf->loadHtml($this->view($data)->render());
 
         $dompdf->render();
 


### PR DESCRIPTION
After the update to Dompdf v0.7.0, it fails to create an invoice with this error:
```
Class 'DOMPDF' not found
```
Applied the same changes with Stripe's Cashier: https://github.com/laravel/cashier/commit/cbc9905195eb80ae331aae66e8cd940e55644471