### PR TITLE
Do not remove trial ending date when swapping subscription

### DIFF
--- a/src/Subscription.php
+++ b/src/Subscription.php
@@ -152,7 +152,6 @@ class Subscription extends Model
             $this->fill([
                 'braintree_plan' => $plan->id,
                 'ends_at' => null,
-                'trial_ends_at' => null,
             ])->save();
         } else {
             throw new Exception('Braintree failed to swap plans: '.$response->message);


### PR DESCRIPTION
If the subscription was created with the trial and the trial has not ended and you have swapped to the other plan, then it would be not possible to cancel it.

After swapping from the first plan with the active trial, the trail_ends_at would be set to NULL.

When you would try to cancel the subscription, \Laravel\Cashier\Subscription::cancel() would try to change the numberOfBillingCycles and Braintree would respond with the error message: Number Of Billing Cycles must be greater than zero, because the Braintree subscription is still on the trial and our local database does not know about it as we changed already trial_ends_at to NULL.