### PR TITLE
Allow for Subscription model extension and pass through $options on existing customers

### DIFF
--- a/src/Billable.php
+++ b/src/Billable.php
@@ -18,6 +18,13 @@ use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 trait Billable
 {
     /**
+     * The Eloquent subscription model name.
+     *
+     * @var string
+     */
+    protected static $subscriptionModel = Subscription::class;
+
+    /**
      * Make a "one off" charge on the customer for the given amount.
      *
      * @param  int  $amount
@@ -165,7 +172,7 @@ trait Billable
      */
     public function subscriptions()
     {
-        return $this->hasMany(Subscription::class)->orderBy('created_at', 'desc');
+        return $this->hasMany(self::$subscriptionModel)->orderBy('created_at', 'desc');
     }
 
     /**

--- a/src/Billable.php
+++ b/src/Billable.php
@@ -329,9 +329,11 @@ trait Billable
             'card_last_four' => $paypalAccount ? null : $response->paymentMethod->last4,
         ])->save();
 
-        $this->updateSubscriptionsToPaymentMethod(
-            $response->paymentMethod->token
-        );
+        if ($response->paymentMethod->default) {
+            $this->updateSubscriptionsToPaymentMethod(
+                $response->paymentMethod->token
+            );
+        }
     }
 
     /**

--- a/src/Billable.php
+++ b/src/Billable.php
@@ -25,6 +25,27 @@ trait Billable
     protected static $subscriptionModel = Subscription::class;
 
     /**
+     * Set the Subscription Model
+     * - Allows for override in constructor
+     *
+     * @param $model
+     */
+    public function setSubscriptionModel($model)
+    {
+        self::$subscriptionModel = $model;
+    }
+
+    /**
+     * Get Subscription Model
+     *
+     * @return string
+     */
+    public function getSubscriptionModel()
+    {
+        return self::$subscriptionModel;
+    }
+
+    /**
      * Make a "one off" charge on the customer for the given amount.
      *
      * @param  int  $amount

--- a/src/SubscriptionBuilder.php
+++ b/src/SubscriptionBuilder.php
@@ -219,7 +219,7 @@ class SubscriptionBuilder
             $customer = $this->owner->asBraintreeCustomer();
 
             if ($token) {
-                $this->owner->updateCard($token);
+                $this->owner->updateCard($token, $options);
             }
         }
 


### PR DESCRIPTION
I added a getter and setter for the subscription model so it can be overridden in the constructor.
This allows for extension of the subscription model (talked about in https://github.com/laravel/cashier/issues/367 )

Added $options to the updateCard() call, I noticed the functionality was there it just wasn't being passed through.

Also added a check before updateSubscriptionsToPaymentMethod() to ensure that it only updates all subscriptions if the card is set to default (which can now be overridden by passing through an option).

These things were pretty specific to my useage case but I thought I'd send a PR just incase you think its relevant to everyone.