### PR TITLE
Update Billable.php to fix on create user and sub.

### DIFF
--- a/src/Billable.php
+++ b/src/Billable.php
@@ -425,6 +425,8 @@ trait Billable
         if (! $response->success) {
             throw new Exception('Unable to create Braintree customer: '.$response->message);
         }
+        
+        $this->braintree_id = $response->customer->id;
 
         $paymentMethod = $this->paymentMethod();
 


### PR DESCRIPTION
This change is proposed due to the following bug:

on payment POST form processing, when executing the following:
$request->user()->newSubscription('main', $plan->braintree_plan)->create($request->payment_method_nonce, $user_data);

I end up with this bug:
(1/1) InvalidArgumentException
expected customer id to be set
in CustomerGateway.php (line 578)
at CustomerGateway->_validateId(null)
in CustomerGateway.php (line 209)
at CustomerGateway->find(null)
in Customer.php (line 107)
at Customer::find(null)
in Billable.php (line 460)
at User->asBraintreeCustomer()
in Billable.php (line 355)
at User->paymentMethod()
in Billable.php (line 429)
at User->createAsBraintreeCustomer('80541492-beaf-0667-6ccb-295ad86ccc2e', array('id' => 'myservice_21', 'email' => 'nmpribeiro@gmail.com'))
in SubscriptionBuilder.php (line 216)
at SubscriptionBuilder->getBraintreeCustomer('80541492-beaf-0667-6ccb-295ad86ccc2e', array('id' => 'myservice_21', 'email' => 'nmpribeiro@gmail.com'))
in SubscriptionBuilder.php (line 131)
at SubscriptionBuilder->create('80541492-beaf-0667-6ccb-295ad86ccc2e', array('id' => 'myservice_21', 'email' => 'nmpribeiro@gmail.com'), array())
in SubscriptionsController.php (line 26)
at SubscriptionsController->store(object(Request))
at call_user_func_array(array(object(SubscriptionsController), 'store'), array(object(Request)))
in Controller.php (line 55)
at Controller->callAction('store', array(object(Request)))
in ControllerDispatcher.php (line 44)
at ControllerDispatcher->dispatch(object(Route), object(SubscriptionsController), 'store')
in Route.php (line 203)
at Route->runController()
in Route.php (line 160)

User has no 'braintree_id' yet. This is it's first checkout/subscription.
Basically, first 'createAsBraintreeCustomer' is called (following stack trace):
L409: User->createAsBraintreeCustomer($nonce, $user_data=['id'=>"some_id_".$user->id]);
then, 'User->paymentMethod()' is issued on L431: $paymentMethod = $this->paymentMethod();
this method issues 'User->asBraintreeCustomer()' on L355: $customer = $this->asBraintreeCustomer();
which then tries to return 'return BraintreeCustomer::find($this->braintree_id);'

However, reaching this line, $this->braintree_id is not yet assigned in Billable class, as such BraintreeCustomer throws the error 'expected customer id to be set'. If we assign it after creating it, on L411, and after passing the $response->success conditional, we then allow proper flow execution and the bug is not present anymore. The customer creation should be a method by itself that populated a proper customer object inside Billable.

As such, this is only a quick fix.

I hope that, at least, someone could fix with a proper commit, instead of refusing my proposal altogether.
Thanks in advance!