### PR TITLE
[3.0] Updated to PHPUnit 6 and Mockery 1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,8 @@
 language: php
 
 php:
-  - 5.6
   - 7.0
   - 7.1
-  - hhvm
 
 sudo: false
 

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         }
     ],
     "require": {
-        "php": ">=5.5.9",
+        "php": ">=7.0",
         "illuminate/database": "~5.3",
         "illuminate/support": "~5.3",
         "braintree/braintree_php": "~3.0",
@@ -19,11 +19,11 @@
         "symfony/http-kernel": "~2.7|~3.0"
     },
     "require-dev": {
-        "illuminate/routing": "~5.3",
         "illuminate/http": "~5.3",
+        "illuminate/routing": "~5.3",
         "illuminate/view": "~5.3",
-        "mockery/mockery": "~0.9",
-        "phpunit/phpunit": "~4.0",
+        "mockery/mockery": "~1.0",
+        "phpunit/phpunit": "~6.0",
         "vlucas/phpdotenv": "~2.0"
     },
     "autoload": {

--- a/tests/CashierTest.php
+++ b/tests/CashierTest.php
@@ -2,11 +2,12 @@
 
 use Carbon\Carbon;
 use Illuminate\Http\Request;
+use PHPUnit\Framework\TestCase;
 use Illuminate\Database\Capsule\Manager as DB;
 use Illuminate\Database\Eloquent\Model as Eloquent;
 use Laravel\Cashier\Http\Controllers\WebhookController;
 
-class CashierTest extends PHPUnit_Framework_TestCase
+class CashierTest extends TestCase
 {
     public static function setUpBeforeClass()
     {

--- a/tests/WebhookControllerTest.php
+++ b/tests/WebhookControllerTest.php
@@ -1,9 +1,10 @@
 <?php
 
 use Illuminate\Http\Request;
+use PHPUnit\Framework\TestCase;
 use Laravel\Cashier\Http\Controllers\WebhookController;
 
-class WebhookControllerTest extends PHPUnit_Framework_TestCase
+class WebhookControllerTest extends TestCase
 {
     public function testProperMethodsAreCalledBasedOnBraintreeEvent()
     {


### PR DESCRIPTION
Updated `phpunit/phpunit` to `~6.0` and `mockery/mockery` to `~1.0`

Dropped support to `PHP 5.6` and `HHVM`, as PHPUnit 6.0 [requires PHP 7.0](https://github.com/sebastianbergmann/phpunit/blob/master/composer.json#L25).