### PR TITLE
Use default payment method

### DIFF
--- a/src/SubscriptionBuilder.php
+++ b/src/SubscriptionBuilder.php
@@ -177,7 +177,7 @@ class SubscriptionBuilder
         return array_merge([
             'planId' => $this->plan,
             'price' => (string) round($plan->price * (1 + ($this->owner->taxPercentage() / 100)), 2),
-            'paymentMethodToken' => $customer->defaultPaymentMethod()->token,
+            'paymentMethodToken' => $this->owner->paymentMethod()->token,
             'trialPeriod' => $this->trialDays && ! $this->skipTrial ? true : false,
             'trialDurationUnit' => 'day',
             'trialDuration' => $trialDuration,

--- a/src/SubscriptionBuilder.php
+++ b/src/SubscriptionBuilder.php
@@ -177,7 +177,7 @@ class SubscriptionBuilder
         return array_merge([
             'planId' => $this->plan,
             'price' => (string) round($plan->price * (1 + ($this->owner->taxPercentage() / 100)), 2),
-            'paymentMethodToken' => $customer->paymentMethods[0]->token,
+            'paymentMethodToken' => $customer->defaultPaymentMethod()->token,
             'trialPeriod' => $this->trialDays && ! $this->skipTrial ? true : false,
             'trialDurationUnit' => 'day',
             'trialDuration' => $trialDuration,


### PR DESCRIPTION
When more than one Payment Method is added, use the default one instead of the first one