### PR TITLE
Use default payment method for new subscription

### DIFF
--- a/src/SubscriptionBuilder.php
+++ b/src/SubscriptionBuilder.php
@@ -177,7 +177,7 @@ class SubscriptionBuilder
         return array_merge([
             'planId' => $this->plan,
             'price' => (string) round($plan->price * (1 + ($this->owner->taxPercentage() / 100)), 2),
-            'paymentMethodToken' => $customer->defaultPaymentMethod()->token,
+            'paymentMethodToken' => $this->owner->paymentMethod()->token,
             'trialPeriod' => $this->trialDays && ! $this->skipTrial ? true : false,
             'trialDurationUnit' => 'day',
             'trialDuration' => $trialDuration,

--- a/src/SubscriptionBuilder.php
+++ b/src/SubscriptionBuilder.php
@@ -177,7 +177,7 @@ class SubscriptionBuilder
         return array_merge([
             'planId' => $this->plan,
             'price' => (string) round($plan->price * (1 + ($this->owner->taxPercentage() / 100)), 2),
-            'paymentMethodToken' => $customer->paymentMethods[0]->token,
+            'paymentMethodToken' => $customer->defaultPaymentMethod()->token,
             'trialPeriod' => $this->trialDays && ! $this->skipTrial ? true : false,
             'trialDurationUnit' => 'day',
             'trialDuration' => $trialDuration,


### PR DESCRIPTION
The current version just uses the payment method at index 0. This will always be a credit card if more than one payment method is added.

Note: the $customer->defaultPaymentMethod()->token does somehow not work, probably because the object is initalized before updateCard is called?  I guess that's why my previous pull request did not work. 
This version uses the Billable function paymentMethod() to retrieve the default payment, which works, but I think it makes yet another request to Braintree to fetch the new customer object.
