### PR TITLE
Add support for quantities through Addons

### DIFF
--- a/src/Subscription.php
+++ b/src/Subscription.php
@@ -159,7 +159,7 @@ class Subscription extends Model
                 : ['add' => [['inheritedFromId' => $addonName, 'quantity' => $quantity]]];
         }
 
-        BraintreeSubscription::update($this->braintree_id, ['addOns' => $options,]);
+        BraintreeSubscription::update($this->braintree_id, ['addOns' => $options]);
 
         $this->quantity = $quantity + 1;
 

--- a/src/Subscription.php
+++ b/src/Subscription.php
@@ -114,6 +114,63 @@ class Subscription extends Model
     }
 
     /**
+     * Increment the quantity of the subscription.
+     *
+     * @param  int  $count
+     * @return $this
+     */
+    public function incrementQuantity($count = 1)
+    {
+        $this->updateQuantity($this->quantity + $count);
+
+        return $this;
+    }
+
+    /**
+     * Decrement the quantity of the subscription.
+     *
+     * @param  int  $count
+     * @return $this
+     */
+    public function decrementQuantity($count = 1)
+    {
+        $this->updateQuantity($this->quantity - $count);
+
+        return $this;
+    }
+
+    /**
+     * Update the quantity of the subscription.
+     *
+     * @param  int  $quantity
+     * @return $this
+     */
+    public function updateQuantity($quantity)
+    {
+        $quantity = max(0, $quantity - 1);
+
+        $addonName = $this->braintree_plan.'-quantity';
+
+        $options = ['remove' => [$addonName]];
+
+        if ($quantity > 0) {
+            $options = $this->quantity > 1
+                ? ['update' => [['existingId' => $addonName, 'quantity' => $quantity]]]
+                : ['add' => [['inheritedFromId' => $addonName, 'quantity' => $quantity]]];
+        }
+
+        BraintreeSubscription::update($this->braintree_id, [
+            'addOns' => $options,
+        ]);
+
+        $this->quantity = $quantity + 1;
+
+        $this->save();
+
+        return $this;
+    }
+
+    /**
      * Swap the subscription to a new Braintree plan.
      *
      * @param  string  $plan

--- a/src/Subscription.php
+++ b/src/Subscription.php
@@ -159,9 +159,7 @@ class Subscription extends Model
                 : ['add' => [['inheritedFromId' => $addonName, 'quantity' => $quantity]]];
         }
 
-        BraintreeSubscription::update($this->braintree_id, [
-            'addOns' => $options,
-        ]);
+        BraintreeSubscription::update($this->braintree_id, ['addOns' => $options,]);
 
         $this->quantity = $quantity + 1;
 


### PR DESCRIPTION
Given that subscription initial quantity = 1 and plan name is `basic-plan`, if a user creates an Addon from the dashboard and named it `basic-plan-quantity` and gave it the same price of the plan we can use this to add/update quantity/remove the addon to support quantities.

For example:
On initial state, quantity in subscription database is 1, when user `incrementQuantity()` we add the addon to the subscription, so he now has subscription 2 in the database, and in braintree he'll have the subscription + 1 addon.

User adds more quantity, subscription in database increases and becomes 3, in braintree he'll have 1 subscription + 2 addon.

If user sets quantity to 1, we'll remove all the instances of the addon and keep the subscription.

Braintree docs for addons: https://developers.braintreepayments.com/reference/request/subscription/update/php#add-ons-and-discounts