### PR TITLE
Use number_format instead of round

### DIFF
--- a/src/Billable.php
+++ b/src/Billable.php
@@ -30,7 +30,7 @@ trait Billable
         $customer = $this->asBraintreeCustomer();
 
         $response = BraintreeTransaction::sale(array_merge([
-            'amount' => (string) round($amount * (1 + ($this->taxPercentage() / 100)), 2),
+            'amount' => number_format($amount * (1 + ($this->taxPercentage() / 100)), 2, '.', ''),
             'paymentMethodToken' => $this->paymentMethod()->token,
             'options' => [
                 'submitForSettlement' => true,

--- a/src/Subscription.php
+++ b/src/Subscription.php
@@ -196,7 +196,7 @@ class Subscription extends Model
 
         $response = BraintreeSubscription::update($subscription->id, [
             'planId' => $plan->id,
-            'price' => (string) round($plan->price * (1 + ($this->owner->taxPercentage() / 100)), 2),
+            'price' => number_format($plan->price * (1 + ($this->owner->taxPercentage() / 100)), 2, '.', ''),
             'neverExpires' => true,
             'numberOfBillingCycles' => null,
             'options' => [

--- a/src/SubscriptionBuilder.php
+++ b/src/SubscriptionBuilder.php
@@ -176,7 +176,7 @@ class SubscriptionBuilder
 
         return array_merge([
             'planId' => $this->plan,
-            'price' => (string) round($plan->price * (1 + ($this->owner->taxPercentage() / 100)), 2),
+            'price' => number_format($plan->price * (1 + ($this->owner->taxPercentage() / 100)), 2, '.', ''),
             'paymentMethodToken' => $this->owner->paymentMethod()->token,
             'trialPeriod' => $this->trialDays && ! $this->skipTrial ? true : false,
             'trialDurationUnit' => 'day',


### PR DESCRIPTION
With some PHP configurations, it is possible to encounter an error described here: https://stackoverflow.com/questions/33225193/php-round-not-working-properly. I came across this error using this library. Using number_format solves the problem.