### PR TITLE
[3.0] Remove support for Symfony HttpKernel below 4.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         "illuminate/database": "~5.7",
         "illuminate/support": "~5.7",
         "nesbot/carbon": "~1.0",
-        "symfony/http-kernel": "~3.0|~4.0"
+        "symfony/http-kernel": "~4.0"
     },
     "require-dev": {
         "ext-json": "*",


### PR DESCRIPTION
Since this isn't supported with the latest framework version anymore.