### PR TITLE
Fix return type for getSubscriptionById on the WebhookController

### DIFF
--- a/src/Http/Controllers/WebhookController.php
+++ b/src/Http/Controllers/WebhookController.php
@@ -88,9 +88,9 @@ class WebhookController extends Controller
      * Get the model for the given subscription ID.
      *
      * @param  string  $subscriptionId
-     * @return \Laravel\Cashier\Subscription
+     * @return \Laravel\Cashier\Subscription|null
      */
-    protected function getSubscriptionById($subscriptionId): Subscription
+    protected function getSubscriptionById($subscriptionId): ?Subscription
     {
         return Subscription::where('braintree_id', $subscriptionId)->first();
     }


### PR DESCRIPTION
I think the return type here was too strict, since the `find` method could return null, e.g. if a subscription has been deleted, and that would cause an error.

Also, on the `cancelSubscription` method we are checking if the `$subscription` is truthy, which means that is a valid case.