### PR TITLE
[3.0] Update version of nesbot/carbon to match framework

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "dompdf/dompdf": "^0.8.0",
         "illuminate/database": "~5.7.0|~5.8.0",
         "illuminate/support": "~5.7.0|~5.8.0",
-        "nesbot/carbon": "~1.0",
+        "nesbot/carbon": "^1.26.3 || ^2.0",
         "symfony/http-kernel": "~4.0"
     },
     "require-dev": {


### PR DESCRIPTION
Trying to install v3.1 results in the following:

```
Problem 1
    - Installation request for laravel/cashier-braintree ^3.1 -> satisfiable by laravel/cashier-braintree[v3.1.0].
    - laravel/cashier-braintree v3.1.0 requires nesbot/carbon ~1.0 -> satisfiable by nesbot/carbon[1.0.0, 1.0.1, 1.1.0, 1.10.0, 1.11.0, 1.12.0, 1.13.0, 1.14.0, 1.15.0, 1.16.0, 1.17.0, 1.18.0, 1.19.0, 1.2.0, 1.20.0, 1.21.0, 1.22.0, 1.22.1, 1.23.0, 1.24.0, 1.24.1, 1.24.2, 1.25.0, 1.26.0, 1.26.1, 1.26.2, 1.26.3, 1.26.4, 1.27.0, 1.28.0, 1.29.0, 1.29.1, 1.29.2, 1.3.0, 1.30.0, 1.31.0, 1.31.1, 1.32.0, 1.33.0, 1.34.0, 1.34.1, 1.34.2, 1.34.3, 1.34.4, 1.35.0, 1.35.1, 1.36.0, 1.36.1, 1.36.2, 1.4.0, 1.5.0, 1.6.0, 1.7.0, 1.8.0, 1.9.0] but these conflict with your requirements or minimum-stability.
```

This bumps the carbon version to allow this to install properly